### PR TITLE
Change 'undefined' host from 255.255.255.255 to ''

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -16,6 +16,7 @@ We currently support the following actions:
 * **Next:** Move the selection down one cue.
 * **Previous:** Move the selection up one cue.
 * **Start (cue):** Start the specified cue. If the specified cue is playing, this command has no effect.
+* **Preview:** Preview the selected cue without moving the Playhead.
 * **Increase Prewait:** Increases the prewait time by given time for the selected cue
 * **Decrease Prewait:** Decreases the prewait time by given time for the selected cue
 * **Increase postwait:** Increases the postwait time by given time for the selected cue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qlab",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/qlab.js
+++ b/qlab.js
@@ -1117,7 +1117,7 @@ instance.prototype.action = function (action) {
 		arg = [];
 	}
 
-	var host = "255.255.255.255";
+	var host = "";
 	if (self.config.host !== undefined && self.config.host !== '') {
 		host = self.config.host;
 	}


### PR DESCRIPTION
My edit/develop/test system is on Linux, so all of my testing of QLab uses the host IP of my macbook.

Updating the module to check for 'undefined' I substituted the broadcast address.
For me this worked, but apparently broadcast does not include localhost.
So it had the effect of working everywhere EXCEPT localhost.

Using an empty host address results in the prior behavior of sending messages to localhost.