### PR TITLE
misc spelling and casing

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -4,7 +4,7 @@ What does QLab do?
 QLab makes it simple to create intricate designs of light, sound, and video, which you play back during a live performance.
 QLab allows you to lock in exactly how you want the light, sound, and video to play during your performance. When you’re done designing, you'll switch to “show mode” and run your show just by pressing “GO”.
 
-Go over to [figure 53](https://figure53.com/) and checkout the software.
+Go over to [Figure 53](https://figure53.com/) and checkout the software.
 
 We currently support the following actions:
 * **Go:** Tell the current cue list of the given workspace to GO.
@@ -32,10 +32,10 @@ We currently support the following actions:
 * **Set Continue Mode:** Sets the continue mode of the selected cue
 * **Set Cue Color:** Sets the color of the selected cue
 
-for additional actions please raise a feature request at [github](https://github.com/bitfocus/companion)
+for additional actions please raise a feature request at [GitHub](https://github.com/bitfocus/companion)
 
 ### OSC
 Sends OSC commands to port 53000.
 
-From Qlab preferences OSC controls tab make sure you have the "Use OSC controls" checkbox ticked.
-![Qlab](images/qlab.jpg?raw=true "Qlab")
+From QLab preferences OSC controls tab make sure you have the "Use OSC controls" checkbox ticked.
+![QLab](images/qlab.jpg?raw=true "QLab")

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"manufacturer": "Figure 53",
 	"product": "QLab",
 	"shortname": "qlab",
-	"description": "Qlab plugin for Companion",
+	"description": "QLab plugin for Companion",
 	"main": "qlab.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/qlab.js
+++ b/qlab.js
@@ -61,7 +61,7 @@ instance.prototype.config_fields = function () {
 			id: 'info',
 			width: 12,
 			label: 'Information',
-			value: 'This module controls Qlab by <a href="https://figure53.com/" target="_new">Figure 53</a>.'
+			value: 'This module controls <a href="https://qlab.app/" target="_blank" rel="noopener noreferrer">QLab</a> by <a href="https://figure53.com/" target="_blank" rel="noopener noreferrer">Figure 53</a>.'
 		},
 		{
 			type: 'textinput',
@@ -74,9 +74,9 @@ instance.prototype.config_fields = function () {
 		{
 			type: 'textinput',
 			id: 'passcode',
-			label: 'OSC Pascode',
+			label: 'OSC Passcode',
 			width: 12,
-			tooltip: 'The passcode for controling QLab, leave blank if not set any'
+			tooltip: 'The passcode for controlling QLab, leave blank if not set any'
 		},
 		{
 			type: 'textinput',


### PR DESCRIPTION
* standardize to "QLab" from "Qlab"
* fix a few misspellings
* correct opening a new window

Signed-off-by: Darin Pope <darin@planetpope.com>